### PR TITLE
Input type set to password for login and signup

### DIFF
--- a/gpt/gpt/gpt.py
+++ b/gpt/gpt/gpt.py
@@ -175,7 +175,7 @@ def login():
     return pc.center(
         pc.vstack(
             pc.input(on_blur=State.set_username, placeholder="Username", width="100%"),
-            pc.input(on_blur=State.set_password, placeholder="Password", width="100%"),
+            pc.input(type_="password", on_blur=State.set_password, placeholder="Password", width="100%"),
             pc.button("Login", on_click=State.login, width="100%"),
             pc.link(pc.button("Sign Up", width="100%"), href="/signup", width="100%"),
         ),
@@ -196,9 +196,10 @@ def signup():
                         on_blur=State.set_username, placeholder="Username", width="100%"
                     ),
                     pc.input(
-                        on_blur=State.set_password, placeholder="Password", width="100%"
+                        type_="password", on_blur=State.set_password, placeholder="Password", width="100%"
                     ),
                     pc.input(
+                        type_="password",
                         on_blur=State.set_password,
                         placeholder="Confirm Password",
                         width="100%",


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19iFjT6auI0gYLMGEKBveNaZVD3FaTU%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=pBHfPd-)
Password was previously visible while being typed out. Changed the input  to `type_="password"`

![image](https://user-images.githubusercontent.com/68660002/213980103-a439dd73-6bae-448a-afa4-d2671c711719.png)
