### PR TITLE
Removed unused imports "plotly.express" and "plotly.graph_objects"

### DIFF
--- a/traversal/traversal/traversal.py
+++ b/traversal/traversal/traversal.py
@@ -1,8 +1,6 @@
 from pcconfig import config
 
 import pynecone as pc
-import plotly.express as px
-import plotly.graph_objects as go
 import random
 import asyncio
 from collections import deque


### PR DESCRIPTION
Hello,

Thank you for maintaining this wonderful repository!


I noticed that the following imports were not used anywhere in the code:

```
import plotly.express as px
import plotly.graph_objects as go
```

Additionally, it appears that having pandas installed is a prerequisite. 

I found that the code was not working due to the reasons mentioned above, and there was no requirements.txt file present. Therefore, I thought it would be appropriate to remove the code. Would you agree with this decision?
