### PR TITLE
requirements.txt update and test to pc 0.1.30

### DIFF
--- a/chatroom/requirements.txt
+++ b/chatroom/requirements.txt
@@ -1,1 +1,1 @@
-pynecone>=0.1.29
+pynecone>=0.1.30

--- a/clock/requirements.txt
+++ b/clock/requirements.txt
@@ -1,2 +1,2 @@
-pynecone>=0.1.29
+pynecone>=0.1.30
 pytz==2022.7.1

--- a/counter/requirements.txt
+++ b/counter/requirements.txt
@@ -1,1 +1,1 @@
-pynecone>=0.1.29
+pynecone>=0.1.30

--- a/crm/requirements.txt
+++ b/crm/requirements.txt
@@ -1,1 +1,1 @@
-pynecone>=0.1.29
+pynecone>=0.1.30

--- a/dalle/requirements.txt
+++ b/dalle/requirements.txt
@@ -1,2 +1,2 @@
-pynecone>=0.1.29
+pynecone>=0.1.30
 openai

--- a/fragments/requirements.txt
+++ b/fragments/requirements.txt
@@ -1,1 +1,1 @@
-pynecone>=0.1.29
+pynecone>=0.1.30

--- a/gpt/requirements.txt
+++ b/gpt/requirements.txt
@@ -1,2 +1,2 @@
-pynecone>=0.1.29
+pynecone>=0.1.30
 openai

--- a/nba/requirements.txt
+++ b/nba/requirements.txt
@@ -1,4 +1,4 @@
-pynecone>=0.1.29
+pynecone>=0.1.30
 plotly-express
 plotly
 pandas

--- a/quiz/requirements.txt
+++ b/quiz/requirements.txt
@@ -1,1 +1,1 @@
-pynecone>=0.1.29
+pynecone>=0.1.30

--- a/sales/requirements.txt
+++ b/sales/requirements.txt
@@ -1,2 +1,2 @@
-pynecone>=0.1.29
+pynecone>=0.1.30
 openai

--- a/snakegame/requirements.txt
+++ b/snakegame/requirements.txt
@@ -1,1 +1,1 @@
-pynecone>=0.1.29
+pynecone>=0.1.30

--- a/todo/requirements.txt
+++ b/todo/requirements.txt
@@ -1,1 +1,1 @@
-pynecone>=0.1.29
+pynecone>=0.1.30

--- a/translator/requirements.txt
+++ b/translator/requirements.txt
@@ -1,3 +1,3 @@
-pynecone>=0.1.29
+pynecone>=0.1.30
 googletrans-py==4.0.0
 requests>=2.28.1

--- a/traversal/requirements.txt
+++ b/traversal/requirements.txt
@@ -1,1 +1,1 @@
-pynecone>=0.1.29
+pynecone>=0.1.30

--- a/twitter/requirements.txt
+++ b/twitter/requirements.txt
@@ -1,1 +1,1 @@
-pynecone>=0.1.29
+pynecone>=0.1.30

--- a/upload/requirements.txt
+++ b/upload/requirements.txt
@@ -1,1 +1,1 @@
-pynecone>=0.1.29
+pynecone>=0.1.30


### PR DESCRIPTION
**It's still in the testing for every example code**
According to the issue https://github.com/pynecone-io/pynecone-examples/issues/55
Update requriement.txt for latest version `pynecone==0.1.30` on PyPI 
- [x] chatroom 
- [x]  clock
- [ ]  counter
- [ ]  crm
- [ ]  dalle
- [ ]  fragments
- [ ]  gpt
- [ ]  nba 
- [ ]  quiz
- [ ]  sales
- [ ]  snakegame
- [ ]  todo
- [ ]  translator
- [ ]  traversal 
- [ ]  twitter 

The box with the check icon is the code we can run on `pynecone==0.1.30`


### Notes


### My Testing Environment
I run all example codes by the following one-line command.   [one-line cmd ??  doc --help](https://hackmd.io/@milochen0418/pctest-0-1-29-script)
```
pip install -r requirements.txt && rm -f pynecone.db && rm -rf .web && for i in $(find ./ | grep __pycache__$); do rm -rf $i; done && echo -e "\033[1;92mMy Testing Environment\033[0m" && echo -e "\t"OS $(uname) $(uname -r) && echo -e "\t"Pynecone $(pc version) && echo -e "\t"$(python --version) && echo -e "\t"Node $(node --version) && echo -e "\t"Bun $(~/.bun/bin/bun --version) && pc init && pc run --loglevel=debug
```


And the test environment is 
```
My Testing Environment
        OS Darwin 22.4.0
        Pynecone 0.1.30
        Python 3.11.3
        Node v16.8.0
        Bun 0.5.9
```


On my computer, my Python version is 3.11.3. 
If some examples here cannot run well, you can use `python 3.11.3`

### The related issues that have been close from these PR updating
`None`
